### PR TITLE
Adding CommonMark (Markdown) linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,12 @@ As a lone programmer one can sometimes forget the importance of writing well str
 * [csscomb](https://github.com/csscomb/csscomb.js)
 * [ie8linter](https://github.com/israelidanny/ie8linter)
 
+##### CommonMark
+
+* [markdownlint](https://github.com/DavidAnson/markdownlint)
+* [mdl](https://github.com/mivok/markdownlint)
+* [remark-lint](https://github.com/wooorm/remark-lint)
+
 ##### Dart
 
 * [linter](https://github.com/dart-lang/linter)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ As a lone programmer one can sometimes forget the importance of writing well str
 * [C++] (#c-plus)
 * [C-Sharp] (#c-sharp)
 * [Clojure] (#clojure)
-* [CommonMark] (#commonmark)
 * [CSS] (#css)
 * [Erlang] (#erlang)
 * [Java] (#java)
@@ -37,6 +36,7 @@ As a lone programmer one can sometimes forget the importance of writing well str
 * [HTML] (#html)
 * [Lisp] (#lisp)
 * [Lua] (#lua)
+* [Markdown] (#markdown)
 * [Node.js] (#nodejs)
 * [Objective-C] (#objective-c)
 * [Perl] (#perl)
@@ -75,10 +75,6 @@ As a lone programmer one can sometimes forget the importance of writing well str
 ##### Clojure
 
 * [Clojure Development](http://dev.clojure.org/display/community/Library+Coding+Standards)
-
-##### CommonMark
-
-* [CommonMark Spec](http://spec.commonmark.org/)
 
 ##### CSS
 
@@ -127,6 +123,11 @@ As a lone programmer one can sometimes forget the importance of writing well str
 
 * [Official Lua](http://lua-users.org/wiki/LuaStyleGuide)
 * [Olivine Labs](https://github.com/Olivine-Labs/lua-style-guide)
+
+##### Markdown
+
+* [John Gruber's Markdown Syntax Documentation](https://daringfireball.net/projects/markdown/syntax)
+* [CommonMark Spec](http://spec.commonmark.org/)
 
 ##### <a name="nodejs"></a> Node.js
 
@@ -214,12 +215,6 @@ As a lone programmer one can sometimes forget the importance of writing well str
 * [csscomb](https://github.com/csscomb/csscomb.js)
 * [ie8linter](https://github.com/israelidanny/ie8linter)
 
-##### CommonMark
-
-* [markdownlint](https://github.com/DavidAnson/markdownlint)
-* [mdl](https://github.com/mivok/markdownlint)
-* [remark-lint](https://github.com/wooorm/remark-lint)
-
 ##### Dart
 
 * [linter](https://github.com/dart-lang/linter)
@@ -255,6 +250,12 @@ As a lone programmer one can sometimes forget the importance of writing well str
 ##### Lua
 
 * [lualint](https://github.com/philips/lualint)
+
+##### Markdown
+
+* [markdownlint](https://github.com/DavidAnson/markdownlint)
+* [mdl](https://github.com/mivok/markdownlint)
+* [remark-lint](https://github.com/wooorm/remark-lint)
 
 ##### Objective-C
 


### PR DESCRIPTION
- [x] Created CommonMark sub-section in linters section
- [x] Added 3 Markdown linters

The tricky thing here is that they are in fact Markdown linters. Markdown is 99% compatible with CommonMark. I do not know whether I should create new section for Markdown (also adding John Gruber's introduction link) or put linters in CommonMark's section. I chose the 2nd variant, but I can redo the commit if you decide to do the opposite.

The bad thing about Markdown is that it does not have full spec and there are many different implementations with their own nuances, like Github-flavoured Markdown. Also it might be misleading for newbies if you have both Markdown and CommonMark sections.