### PR TITLE
Update linters of Golang

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ Here's a complementary list regarding [Coding Standards](https://github.com/cara
 
 ### Go
 
-- [golang](https://github.com/golang/lint)
+- [golint](https://github.com/golang/lint)
+- [gometalinter](https://github.com/alecthomas/gometalinter)
+- [go vet](https://golang.org/cmd/vet/)
 
 ### Haskell
 


### PR DESCRIPTION
- Add go vet and gometalinter
- Rename golang to golint