### PR TITLE
Add awesome badge and remove trailing slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Awesome Lint
+# Awesome Lint [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
 A list of curated tools for static analysis of source code.
 
@@ -93,8 +93,8 @@ Here's a complementary list regarding [Coding Standards](https://github.com/cara
 ### Java
 
 - [checkstyle](https://github.com/checkstyle/checkstyle)
-- [Findbugs](http://findbugs.sourceforge.net/)
-- [PMD](http://pmd.github.io/)
+- [Findbugs](http://findbugs.sourceforge.net)
+- [PMD](http://pmd.github.io)
 
 ### JavaScript
 
@@ -102,7 +102,7 @@ Here's a complementary list regarding [Coding Standards](https://github.com/cara
 - [jshint](https://github.com/jshint/jshint)
 - [node-jscs](https://github.com/jscs-dev/node-jscs)
 - [standard](https://github.com/feross/standard)
-- [xo](https://github.com/sindresorhus/xo/)
+- [xo](https://github.com/sindresorhus/xo)
 
 ### Lua
 
@@ -145,7 +145,7 @@ Here's a complementary list regarding [Coding Standards](https://github.com/cara
 ### Scala
 
 - [Linter](https://github.com/HairyFotr/linter)
-- [Scalastyle](http://www.scalastyle.org/)
+- [Scalastyle](http://www.scalastyle.org)
 - [Scapegoat](https://github.com/sksamuel/scapegoat)
 - [WartRemover](http://github.com/puffnfresh/wartremover)
 


### PR DESCRIPTION
I've added the awesome badge and removed trailing slashes in order to comply with [awesome-lint](https://github.com/sindresorhus/awesome-lint)

Also, I wanted to make a PR and add this very list to [sindresorhus/awesome](https://github.com/sindresorhus/awesome) but since `awesome-lint` is also the name of the linter for awesome lists, to avoid confusion, maybe you could rename this repo to something like `awesome-linters` ?